### PR TITLE
Simplify Silly command definition

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -22,8 +22,8 @@ use Stash\Pool;
 $config = [
     'console' => factory(function (ContainerInterface $c) {
         $app = new Silly\Edition\PhpDi\Application('PHP School Website', null, $c);
-        $app->command('generate-docs', $c->get(GenerateDoc::class));
-        $app->command('clear-cache', $c->get(ClearCache::class));
+        $app->command('generate-docs', GenerateDoc::class);
+        $app->command('clear-cache', ClearCache::class);
         return $app;
     }),
     'app' => factory(function (ContainerInterface $c) {


### PR DESCRIPTION
Hi, just a minor PR.

Silly (with PHP-DI as the container) should be able to auto-resolve class names to invokable objects automatically. The pro is that commands will be instantiated on demand, instead of instantiating all commands when the CLI application boots.