### PR TITLE
Add CGI binary from CLI image

### DIFF
--- a/.docker/files/php-school-fpm/Dockerfile
+++ b/.docker/files/php-school-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.1-fpm AS prod
 
 RUN apt-get -qq update && apt-get install -qqy git zlib1g-dev libzip-dev \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -7,12 +7,16 @@ RUN apt-get -qq update && apt-get install -qqy git zlib1g-dev libzip-dev \
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-#RUN pecl install xdebug && docker-php-ext-enable xdebug
-#ADD .docker/etc/php-xdebug.ini /usr/local/etc/php/conf.d/php-xdebug.ini
-
 COPY . /var/www/html
 WORKDIR /var/www/html
+
+COPY --from=php:8.1-cli /usr/local/bin/php-cgi /usr/local/bin/php-cgi
 
 RUN cd /var/www/html
 
 CMD ["php-fpm"]
+
+FROM prod AS debug
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+ADD .docker/etc/php-xdebug.ini /usr/local/etc/php/conf.d/php-xdebug.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 volumes:
   db_data: {}
 
@@ -8,6 +8,7 @@ services:
     build:
       context: .
       dockerfile: .docker/files/php-school-fpm/Dockerfile
+      target: ${DOCKER_BUILD_TARGET-prod}
     volumes:
       - .:/var/www/html
     environment:


### PR DESCRIPTION
Changes are pretty self-explanatory though not tested exhaustively. 

Pulled in the CGI binary from the respective CLI image, it should be the same arch so my hope is it "just works" but realistically something may fail if a dep hasn't been compiled or something. 

I've upped the compose version so we can use `target` for builds. Why? This allows us to use an env var to target a specific stage of the image build. Layering on essentially dev mode when we want it, but the default being prod