### PR TITLE
Fix closing tabs

### DIFF
--- a/assets/components/ExerciseEditor.vue
+++ b/assets/components/ExerciseEditor.vue
@@ -112,9 +112,24 @@ export default {
       this.loadingResults = false;
     },
     closeTab(tab) {
-      const index = this.openFiles.findIndex(file => file === tab);
+      let index = this.openFiles.findIndex(file => file.name === tab);
 
       this.openFiles.splice(index, 1);
+
+      //if there is a file to the right open, set that as active
+      if (index in this.openFiles) {
+        this.activeTab = index;
+        return;
+      }
+
+      //if there is a file to the left open, set that as active
+      if (index - 1 in this.openFiles) {
+        this.activeTab = index - 1;
+        return;
+      }
+
+      //if there are no more files open
+      this.activeTab = null;
     },
     toTree(files, parent = null) {
       return files.map((file) => {

--- a/assets/components/Tabs.vue
+++ b/assets/components/Tabs.vue
@@ -37,7 +37,7 @@ export default {
         <a href="#" class="">
           {{ tab }}
         </a>
-        <XMarkIcon v-show="disableClose === false" @click="closeTab(tab)" class="cursor-pointer ml-2 w-3 h-3 text-zinc-400"  />
+        <XMarkIcon v-show="disableClose === false" @click.stop="closeTab(tab)" class="cursor-pointer ml-2 w-3 h-3 text-zinc-400 hover:text-white"  />
       </li>
     </ul>
     <template v-for="(tab, index) in tabList">


### PR DESCRIPTION
* Fix closing tabs:
  * When closing a tab in the middle, if there is an open one to the right, set that as active
  * When closing a tab at the end (right), set the immediate one to the left as active
  * If there are no other tabs open, set active to null (don't display an editor) 
* Add hover white on close tab button

Side note: I'm not sure how closing even worked at all, the `this.openFiles.findIndex` call was completely broken, treating `tab` as an object when in fact it was just the string name of the tab.