### PR TITLE
Close tab only if there is one open for this file

### DIFF
--- a/assets/components/ExerciseEditor.vue
+++ b/assets/components/ExerciseEditor.vue
@@ -98,10 +98,13 @@ export default {
     deleteFileOrFolder(file) {
       if (confirm("Are you sure?")){
 
-        //close tab
+        //if this file has an active tab, close it
         const index = this.openFiles.findIndex((elem) => elem === file);
-        this.openFiles.splice(index, 1);
-        this.findAndActivateNearestTab(index);
+        if (index !== -1) {
+          this.openFiles.splice(index, 1  );
+          this.findAndActivateNearestTab(index);
+        }
+
 
         return true;
       }


### PR DESCRIPTION
Only close the tab if there is actually one open. `findIndex` returns `-1` if there is no matching index so we just check for that.

cc @roryhmartin 