### PR TITLE
Fix auto-deploy: SSH repo alias, pin master, trigger on master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,10 @@ name: Deploy
 
 on:
   push:
-    branches: [online]
+    branches: [master]
 
 concurrency:
-  group: deploy-online
+  group: deploy-master
   cancel-in-progress: false
 
 jobs:

--- a/deploy.php
+++ b/deploy.php
@@ -5,7 +5,8 @@ namespace Deployer;
 require 'recipe/common.php';
 
 set('application', 'phpschool');
-set('repository', 'https://github.com/php-school/phpschool.io.git');
+set('repository', 'git@github-phpschool:php-school/phpschool.io.git');
+set('branch', 'master');
 
 set('shared_files', ['.env', 'public/workshops.json']);
 set('shared_dirs', ['var/logs', 'public/uploads']);


### PR DESCRIPTION
Finishes the Capistrano -> PHP Deployer migration so pushes to master auto-deploy phpschool.io.

## Changes
- **deploy.php** `repository` -> `git@github-phpschool:...` — imp's deploy user now has a per-repo read-only deploy key (`phpschool_deploy`) + `Host github-phpschool` SSH alias, avoiding the box-wide `IdentitiesOnly` github.com key that was bound to another repo.
- **deploy.php** `set('branch', 'master')` — the CI runner checks out a detached HEAD, so Deployer would otherwise fall back to the repo default branch `online` (670 commits stale). Pinning guarantees master is deployed.
- **deploy.yml** trigger `online` -> `master` (+ concurrency group) — the workflow only exists on master and `online` has no deploy workflow, so the deploy never fired.

## Server prep (done on imp)
- `/var/www/phpschool.io` manual deploy converted to Deployer layout: `current -> releases/1`, `.dep/latest_release=1`, shared symlinks repointed. releases/1 verified serving 200 as a rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P66wwaJwSSyXxza8ymKito