### PR TITLE
deploy: run writable step via sudo

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -11,6 +11,7 @@ set('branch', 'master');
 set('shared_files', ['.env', 'public/workshops.json']);
 set('shared_dirs', ['var/logs', 'public/uploads']);
 set('writable_dirs', ['var/logs', 'public/uploads']);
+set('writable_use_sudo', true);
 set('keep_releases', 5);
 
 set('git_tty', false);


### PR DESCRIPTION
The first master-triggered deploy reached release 2 and failed only at `deploy:writable`:

```
setfacl: var/logs: Operation not permitted
```

`shared/var/logs` is owned by `www-data:www-data` so the `deploy` user can't `setfacl` it (EPERM), and `shared/public/uploads` was not www-data-writable at all. The deploy user has passwordless sudo, so `writable_use_sudo` runs the ACL step as root — fixing both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P66wwaJwSSyXxza8ymKito