### PR TITLE
deploy: run schema-update through bin/app console

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -33,7 +33,7 @@ task('deploy:clear-cache', function () {
 })->desc('Clear the application cache');
 
 task('deploy:schema-update', function () {
-    run('cd {{release_path}} && {{bin/php}} vendor/bin/doctrine orm:schema-tool:update -f');
+    run('cd {{release_path}} && {{bin/php}} bin/app orm:schema-tool:update -f');
 })->desc('Update the Doctrine schema');
 
 task('deploy:generate-blog', function () {


### PR DESCRIPTION
The deploy failed at `deploy:schema-update`: `vendor/bin/doctrine` has no cli-config.php in this project and can't get an EntityManager. The app's console (`bin/app`) registers the Doctrine ORM commands with a real EntityManager provider, so route the schema update through it: `bin/app orm:schema-tool:update -f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P66wwaJwSSyXxza8ymKito